### PR TITLE
Test/7: nuget integration test support

### DIFF
--- a/ObjectBuildR.sln.DotSettings.user
+++ b/ObjectBuildR.sln.DotSettings.user
@@ -1,4 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=25123138_002D82ff_002D4af4_002D8c16_002Daa16c7bd45a4/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="All tests from Solution" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=3f5c26de_002Db87c_002D4b28_002D93e0_002D97045bd9b806/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="All tests from Solution" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
   &lt;Solution /&gt;
 &lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>

--- a/nuget.integration-tests.config
+++ b/nuget.integration-tests.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="local-packages" value="./artifacts" />
+  </packageSources>
+</configuration>

--- a/src/ObjectBuildR.Generator/ObjectBuildR.Generator.csproj
+++ b/src/ObjectBuildR.Generator/ObjectBuildR.Generator.csproj
@@ -3,10 +3,9 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <IncludeBuildOutput>false</IncludeBuildOutput>
-        <!-- 👇 New project, why not! -->
         <Nullable>enable</Nullable>
         <ImplicitUsings>true</ImplicitUsings>
-        <LangVersion>Latest</LangVersion>
+        <LangVersion>Latest</LangVersion>        
     </PropertyGroup>
 
     <ItemGroup>
@@ -17,5 +16,10 @@
     <ItemGroup>
         <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     </ItemGroup>
-    
+
+    <ItemGroup>
+        <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true"
+              PackagePath="analyzers/dotnet/cs" Visible="false" />
+    </ItemGroup>
+
 </Project>

--- a/test/ObjectBuildR.Generator.NugetIntegrationTests/ObjectBuildR.Generator.NugetIntegrationTests.csproj
+++ b/test/ObjectBuildR.Generator.NugetIntegrationTests/ObjectBuildR.Generator.NugetIntegrationTests.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.5.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.1.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="ObjectBuildR.Generator" Version="1.0.0-alpha" />
+    </ItemGroup>
+
+    <ItemGroup>
+<!--        <Compile Include="..\ObjectBuildR.Generator.IntegrationTests\**\*.cs" Exclude="..\ObjectBuildR.Generator.IntegrationTests\obj" Link="%(RecursiveDir)/%(FileName)%(Extension)"/>-->
+        <Compile Include="..\ObjectBuildR.Generator.IntegrationTests\Entities\**\*.cs" Link="Entities\%(RecursiveDir)\%(FileName)%(Extension)"/>
+        <Compile Include="..\ObjectBuildR.Generator.IntegrationTests\Builders\*.cs" Link="Builders\%(FileName)%(Extension)"/>
+        <Compile Include="..\ObjectBuildR.Generator.IntegrationTests\*.cs" Link="%(FileName)%(Extension)"/>
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Adds a test project that targets the nuget package and uses the tests from the integration test project.
This is currently not implemented to the CI pipeline, this will be done in a future PR.

Closes #7 